### PR TITLE
Fix/update loss enrichment

### DIFF
--- a/payworld-direction-resolver/src/main/java/org/pdzsoftware/payworld_direction_resolver/repository/PaymentRepository.java
+++ b/payworld-direction-resolver/src/main/java/org/pdzsoftware/payworld_direction_resolver/repository/PaymentRepository.java
@@ -1,9 +1,48 @@
 package org.pdzsoftware.payworld_direction_resolver.repository;
 
 import org.pdzsoftware.payworld_direction_resolver.entity.Payment;
+import org.pdzsoftware.payworld_direction_resolver.entity.PaymentStatus;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.mongodb.repository.Update;
 import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Currency;
 
 @Repository
 public interface PaymentRepository extends MongoRepository<Payment, String> {
+    @Query("{ '_id' : ?0 }")
+    @Update("{ '$set' : { " +
+            "'status'           : ?1,  " +
+            "'senderKey'        : ?2,  " +
+            "'receiverKey'      : ?3,  " +
+            "'originalCurrency' : ?4,  " +
+            "'newCurrency'      : ?5,  " +
+            "'originalAmount'   : ?6,  " +
+            "'convertedAmount'  : ?7,  " +
+            "'convertedAt'      : ?8,  " +
+            "'updatedAt'        : ?8   " +
+            "} }")
+    void markPaymentAsEnriched(String uuid,
+                               PaymentStatus status,
+                               String senderKey,
+                               String receiverKey,
+                               Currency originalCurrency,
+                               Currency newCurrency,
+                               BigDecimal originalAmount,
+                               BigDecimal convertedAmount,
+                               LocalDateTime convertedAt);
+
+    @Query("{ '_id' : ?0 }")
+    @Update("{ '$set' : { " +
+            "'status'        : ?1,  " +
+            "'failureReason' : ?2,  " +
+            "'updatedAt'     : ?3   " +
+            "} }")
+    void markPaymentAsFailed(String uuid,
+                             PaymentStatus status,
+                             String failureReason,
+                             LocalDateTime now);
 }

--- a/payworld-ingestor/src/main/java/org/pdzsoftware/payworld_ingestor/controller/PaymentController.java
+++ b/payworld-ingestor/src/main/java/org/pdzsoftware/payworld_ingestor/controller/PaymentController.java
@@ -3,6 +3,8 @@ package org.pdzsoftware.payworld_ingestor.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.pdzsoftware.payworld_ingestor.dto.RawPaymentDTO;
+import org.pdzsoftware.payworld_ingestor.entity.Payment;
+import org.pdzsoftware.payworld_ingestor.entity.PaymentStatus;
 import org.pdzsoftware.payworld_ingestor.publisher.EventPublisher;
 import org.pdzsoftware.payworld_ingestor.service.PaymentService;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,17 +13,19 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @RestController
 @RequestMapping("/api/payments")
 @RequiredArgsConstructor
 public class PaymentController {
     private final PaymentService paymentService;
-    private final EventPublisher eventPublisher;
 
     @PostMapping
     public Mono<Void> postPayment(@RequestBody RawPaymentDTO body) {
-        log.info("[EventPublisher] Received payment request with key: {}", body.getUuid());
-        return paymentService.persistPayment(body).then(eventPublisher.publish(body.getUuid(), body));
+        log.info("[PaymentController] Received payment request with key: {}", body.getUuid());
+        return paymentService.process(body);
+
     }
 }

--- a/payworld-ingestor/src/main/java/org/pdzsoftware/payworld_ingestor/entity/Payment.java
+++ b/payworld-ingestor/src/main/java/org/pdzsoftware/payworld_ingestor/entity/Payment.java
@@ -20,8 +20,9 @@ public class Payment {
     private String receiverKey;
     private BigDecimal originalAmount;
     private PaymentStatus status;
+    private String failureReason;
     private LocalDateTime createdAt;
-    private LocalDateTime updateAt;
+    private LocalDateTime updatedAt;
 
     @Override
     public String toString() {
@@ -31,8 +32,9 @@ public class Payment {
                 ", receiverKey='" + receiverKey + '\'' +
                 ", originalAmount=" + originalAmount +
                 ", status=" + status +
+                ", failureReason='" + failureReason + '\'' +
                 ", createdAt=" + createdAt +
-                ", updateAt=" + updateAt +
+                ", updatedAt=" + updatedAt +
                 '}';
     }
 }

--- a/payworld-ingestor/src/main/java/org/pdzsoftware/payworld_ingestor/publisher/EventPublisher.java
+++ b/payworld-ingestor/src/main/java/org/pdzsoftware/payworld_ingestor/publisher/EventPublisher.java
@@ -25,13 +25,6 @@ public class EventPublisher {
         SenderRecord<String, RawPaymentDTO, String> record =
                 SenderRecord.create(new ProducerRecord<>(topic, key, message), key);
 
-        return kafkaSender.send(Mono.just(record))
-                .doOnNext(result -> {
-                    if (result.exception() == null) {
-                        log.info("[EventPublisher] Sent message with key: {}", key);
-                    } else {
-                        log.error("[EventPublisher] Error sending message for key {}: ", key, result.exception());
-                    }
-                }).then();
+        return kafkaSender.send(Mono.just(record)).then();
     }
 }

--- a/payworld-ingestor/src/main/java/org/pdzsoftware/payworld_ingestor/repository/PaymentRepository.java
+++ b/payworld-ingestor/src/main/java/org/pdzsoftware/payworld_ingestor/repository/PaymentRepository.java
@@ -1,9 +1,25 @@
 package org.pdzsoftware.payworld_ingestor.repository;
 
 import org.pdzsoftware.payworld_ingestor.entity.Payment;
+import org.pdzsoftware.payworld_ingestor.entity.PaymentStatus;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.mongodb.repository.Update;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
 
 @Repository
 public interface PaymentRepository extends ReactiveCrudRepository<Payment, String> {
+    @Query("{ '_id' : ?0 }")
+    @Update("{ '$set' : { " +
+            "'status'        : ?1,  " +
+            "'failureReason' : ?2,  " +
+            "'updatedAt'     : ?3   " +
+            "} }")
+    Mono<Void> markPaymentAsFailed(String uuid,
+                                   PaymentStatus status,
+                                   String failureReason,
+                                   LocalDateTime now);
 }

--- a/payworld-ingestor/src/main/java/org/pdzsoftware/payworld_ingestor/service/PaymentService.java
+++ b/payworld-ingestor/src/main/java/org/pdzsoftware/payworld_ingestor/service/PaymentService.java
@@ -5,29 +5,70 @@ import lombok.extern.slf4j.Slf4j;
 import org.pdzsoftware.payworld_ingestor.dto.RawPaymentDTO;
 import org.pdzsoftware.payworld_ingestor.entity.Payment;
 import org.pdzsoftware.payworld_ingestor.entity.PaymentStatus;
+import org.pdzsoftware.payworld_ingestor.publisher.EventPublisher;
 import org.pdzsoftware.payworld_ingestor.repository.PaymentRepository;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+
+import static org.pdzsoftware.payworld_ingestor.entity.PaymentStatus.FAILED_AT_PUBLISHING;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
     private final PaymentRepository paymentRepository;
+    private final EventPublisher eventPublisher;
 
-    public Mono<Payment> persistPayment(RawPaymentDTO rawPayment) {
-        Payment paymentEntity = Payment.builder()
-                .uuid(rawPayment.getUuid())
-                .senderKey(rawPayment.getSenderKey())
-                .receiverKey(rawPayment.getReceiverKey())
-                .originalAmount(rawPayment.getAmount())
+    public Mono<Void> process(RawPaymentDTO body) {
+        return paymentRepository.save(buildPaymentEntity(body))
+                .doOnSuccess(p -> handleSaveSuccess(body.getUuid()))
+                .onErrorResume(e -> handleSaveError(body.getUuid(), e))
+                .flatMap(p -> eventPublisher.publish(body.getUuid(), body)
+                        .doOnSuccess(v -> handlePublishSuccess(body.getUuid()))
+                        .onErrorResume(e -> handlePublishError(body, e))
+                );
+    }
+
+    private void handleSaveSuccess(String uuid) {
+        log.info("[PaymentService] Saved payment with uuid: {} as CREATED in MongoDB", uuid);
+    }
+
+    private Mono<Payment> handleSaveError(String uuid, Throwable e) {
+        log.error("[PaymentService] Error saving payment with uuid: {}, reason: {}", uuid, e.getMessage(), e);
+        return Mono.empty();
+    }
+
+    private void handlePublishSuccess(String uuid) {
+        log.info("[EventPublisher] Sent message with key: {}", uuid);
+    }
+
+    private Mono<Void> handlePublishError(RawPaymentDTO body, Throwable e) {
+        log.error("[EventPublisher] Error sending message with key: {}, reason: {}",
+                body.getUuid(), e.getMessage(), e);
+
+        return paymentRepository.markPaymentAsFailed(
+                        body.getUuid(),
+                        FAILED_AT_PUBLISHING,
+                        e.getMessage(),
+                        LocalDateTime.now()
+                ).doOnSuccess(v -> handleUpdateSuccess(body.getUuid()));
+    }
+
+    private void handleUpdateSuccess(String uuid) {
+        log.info("[PaymentService] Marked payment with uuid: {} as FAILED_AT_PUBLISHING in MongoDB", uuid);
+    }
+
+    private static Payment buildPaymentEntity(RawPaymentDTO body) {
+        return Payment.builder()
+                .uuid(body.getUuid())
+                .senderKey(body.getSenderKey())
+                .receiverKey(body.getReceiverKey())
+                .originalAmount(body.getAmount())
                 .status(PaymentStatus.CREATED)
-                .createdAt(rawPayment.getCreatedAt())
-                .updateAt(rawPayment.getCreatedAt())
+                .createdAt(body.getCreatedAt())
+                .updatedAt(body.getCreatedAt())
                 .build();
-
-        return paymentRepository.save(paymentEntity)
-                .doOnSuccess(saved -> log.info("[PaymentService] Saved payment to MongoDB: {}", saved))
-                .doOnError(e -> log.error("[PaymentService] Error persisting payment: {}", paymentEntity, e));
     }
 }

--- a/payworld-payment-processor/src/main/java/org/pdzsoftware/payworld_payment_processor/listener/EventListener.java
+++ b/payworld-payment-processor/src/main/java/org/pdzsoftware/payworld_payment_processor/listener/EventListener.java
@@ -17,7 +17,7 @@ public class EventListener {
 
     @KafkaListener(topics = "${app.topic.consume}", containerFactory = "kafkaListenerContainerFactory")
     public void onMessage(EnrichedPaymentDTO message, @Header(KafkaHeaders.RECEIVED_KEY) String key) {
-        log.info("Received message with key: {}", key);
+        log.info("[EventListener] Received message with key: {}", key);
         paymentService.processPayment(message);
     }
 }

--- a/payworld-payment-processor/src/main/java/org/pdzsoftware/payworld_payment_processor/repository/mongo/MongoPaymentRepository.java
+++ b/payworld-payment-processor/src/main/java/org/pdzsoftware/payworld_payment_processor/repository/mongo/MongoPaymentRepository.java
@@ -1,6 +1,7 @@
 package org.pdzsoftware.payworld_payment_processor.repository.mongo;
 
 import org.pdzsoftware.payworld_payment_processor.entity.MongoPayment;
+import org.pdzsoftware.payworld_payment_processor.entity.MongoPaymentStatus;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.Update;
@@ -12,20 +13,22 @@ import java.time.LocalDateTime;
 public interface MongoPaymentRepository extends MongoRepository<MongoPayment, String> {
     @Query("{ '_id' : ?0 }")
     @Update("{ '$set' : { " +
-            "'status'      : 'COMPLETED',  " +
-            "'processedAt' : ?1,  " +
-            "'updatedAt'   : ?1   " +
+            "'status'      : ?1,  " +
+            "'processedAt' : ?2,  " +
+            "'updatedAt'   : ?2   " +
             "} }")
-    long markPaymentAsCompleted(String uuid,
+    void markPaymentAsCompleted(String uuid,
+                                MongoPaymentStatus status,
                                 LocalDateTime now);
 
     @Query("{ '_id' : ?0 }")
     @Update("{ '$set' : { " +
-            "'status'        : 'FAILED_AT_PROCESSING',  " +
-            "'failureReason' : ?1,  " +
-            "'updatedAt'     : ?2   " +
+            "'status'        : ?1,  " +
+            "'failureReason' : ?2,  " +
+            "'updatedAt'     : ?3   " +
             "} }")
-    long markPaymentAsFailedProcessing(String uuid,
-                                       String failureReason,
-                                       LocalDateTime now);
+    void markPaymentAsFailed(String uuid,
+                             MongoPaymentStatus status,
+                             String failureReason,
+                             LocalDateTime now);
 }

--- a/payworld-payment-processor/src/main/java/org/pdzsoftware/payworld_payment_processor/repository/mongo/MongoPaymentRepository.java
+++ b/payworld-payment-processor/src/main/java/org/pdzsoftware/payworld_payment_processor/repository/mongo/MongoPaymentRepository.java
@@ -2,8 +2,30 @@ package org.pdzsoftware.payworld_payment_processor.repository.mongo;
 
 import org.pdzsoftware.payworld_payment_processor.entity.MongoPayment;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.mongodb.repository.Update;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
 
 @Repository
 public interface MongoPaymentRepository extends MongoRepository<MongoPayment, String> {
+    @Query("{ '_id' : ?0 }")
+    @Update("{ '$set' : { " +
+            "'status'      : 'COMPLETED',  " +
+            "'processedAt' : ?1,  " +
+            "'updatedAt'   : ?1   " +
+            "} }")
+    long markPaymentAsCompleted(String uuid,
+                                LocalDateTime now);
+
+    @Query("{ '_id' : ?0 }")
+    @Update("{ '$set' : { " +
+            "'status'        : 'FAILED_AT_PROCESSING',  " +
+            "'failureReason' : ?1,  " +
+            "'updatedAt'     : ?2   " +
+            "} }")
+    long markPaymentAsFailedProcessing(String uuid,
+                                       String failureReason,
+                                       LocalDateTime now);
 }

--- a/payworld-payment-processor/src/main/java/org/pdzsoftware/payworld_payment_processor/service/PaymentService.java
+++ b/payworld-payment-processor/src/main/java/org/pdzsoftware/payworld_payment_processor/service/PaymentService.java
@@ -60,8 +60,8 @@ public class PaymentService {
         }
     }
 
-    // Starting a new transaction so it does not roll this specific block back
-    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    // Snapping outside the transaction so it does not roll this specific block back
+    @Transactional(Transactional.TxType.NOT_SUPPORTED)
     private void handleProcessingFailed(EnrichedPaymentDTO enrichedPayment, Exception e) {
         log.error("[PaymentService] Error while processing payment with key: {}, reason: {}",
                 enrichedPayment.getUuid(), e.getMessage());


### PR DESCRIPTION
Fixed occasional inconsistencies by implementing more linear status update flows and kafka publishes. Now the applications only publish to a topic after they have already persisted/updated the mongoDB entity, so there's no risk of an update operation executing after the next app has already consumed the record from the topic.

Also switched to update statements rather than relying on the .save() method of Mongo's Spring abstraction, so it actually performs an update instead of a replacement.